### PR TITLE
docs: refresh docs for Feature Transformation DSL and current API

### DIFF
--- a/docs/api_reference.rst
+++ b/docs/api_reference.rst
@@ -3,26 +3,57 @@ API Reference
 
 This page provides detailed documentation for all public classes and functions in skfeaturellm.
 
+
 Core Classes
------------
+------------
 
 .. automodule:: skfeaturellm.feature_engineer
    :members:
    :undoc-members:
    :show-inheritance:
 
+
 LLM Interface
-------------
+-------------
 
 .. automodule:: skfeaturellm.llm_interface
    :members:
    :undoc-members:
    :show-inheritance:
 
+
+Schemas
+-------
+
+.. automodule:: skfeaturellm.schemas
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+
 Feature Evaluation
-----------------
+------------------
 
 .. automodule:: skfeaturellm.feature_evaluation
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+
+Reporting
+---------
+
+.. automodule:: skfeaturellm.reporting
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+
+Transformations
+---------------
+The Feature Transformation DSL: structured, validated transformations for feature engineering.
+
+.. automodule:: skfeaturellm.transformations
    :members:
    :undoc-members:
    :show-inheritance:

--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -6,73 +6,97 @@ This page contains practical examples of using ``skfeaturellm`` in different sce
 
 Classification
 --------------
-Example applied to a classification task. The example uses the `Iris plants dataset <https://scikit-learn.org/stable/datasets/toy_dataset.html#iris-dataset>`_  from `sklearn.datasets`. The `LLMFeatureEngineer` class is then used to perform feature engineering on the dataset.
+Example applied to a classification task using the `Iris plants dataset <https://scikit-learn.org/stable/datasets/toy_dataset.html#iris-dataset>`_ from ``sklearn.datasets``. The ``LLMFeatureEngineer`` uses an LLM to generate feature ideas (e.g., ratios, log transforms) and then executes them via the Feature Transformation DSL.
 
 .. code-block:: python
 
     from sklearn.datasets import load_iris
-    from skfeaturellm.feature_engineer import LLMFeatureEngineer
+    from skfeaturellm import LLMFeatureEngineer
 
     iris_data = load_iris(as_frame=True)
     X, y = iris_data.data, iris_data.target
 
-    target_column = (
+    target_description = (
         "Classification task predicting species of iris plants "
         "(3 classes: setosa, versicolor, virginica)"
     )
     feature_descriptions = [
-        {"name": "sepal length (cm)", "type": "float", "description": "The sepal lengths in centimeters"},
-        {"name": "sepal width (cm)", "type": "float", "description": "The sepal widths in centimeters"},
-        {"name": "petal length (cm)", "type": "float", "description": "The petal lengths in centimeters"},
-        {"name": "petal width (cm)", "type": "float", "description": "The petal widths in centimeters"},
+        {"name": "sepal length (cm)", "type": "float64", "description": "The sepal lengths in centimeters"},
+        {"name": "sepal width (cm)", "type": "float64", "description": "The sepal widths in centimeters"},
+        {"name": "petal length (cm)", "type": "float64", "description": "The petal lengths in centimeters"},
+        {"name": "petal width (cm)", "type": "float64", "description": "The petal widths in centimeters"},
     ]
 
-    llm_feature_engineer = LLMFeatureEngineer(y_col=target_column)
+    llm_feature_engineer = LLMFeatureEngineer(
+        problem_type="classification",
+        model_name="gpt-4o",
+        max_features=5,
+    )
 
-    # Fit the LLMFeatureEngineer
-    llm_feature_engineer.fit(X, y, feature_descriptions=feature_descriptions)
+    llm_feature_engineer.fit(
+        X=X,
+        feature_descriptions=feature_descriptions,
+        target_description=target_description,
+    )
 
-    # Transform the data
     X_transformed = llm_feature_engineer.transform(X)
-
     print(X_transformed.head())
     print(X_transformed.columns)
 
 
 Regression
 -----------
-Example applied to a regression task. The example uses the `Diabetes dataset <https://scikit-learn.org/stable/datasets/toy_dataset.html#diabetes-dataset>`_  from `sklearn.datasets`. The `LLMFeatureEngineer` class is then used to perform feature engineering on the dataset.
+Example applied to a regression task using the `Diabetes dataset <https://scikit-learn.org/stable/datasets/toy_dataset.html#diabetes-dataset>`_ from ``sklearn.datasets``.
 
 .. code-block:: python
 
     from sklearn.datasets import load_diabetes
-    from skfeaturellm.feature_engineer import LLMFeatureEngineer
+    from skfeaturellm import LLMFeatureEngineer
 
     diabetes_data = load_diabetes(as_frame=True)
     X, y = diabetes_data.data, diabetes_data.target
 
-    target_column = "Regression task predicting the quantitative measure of disease progression one year after baselines"
-    norm_method = "mean centered and scaled by the standard deviation times the square root of n_samples (i.e. the sum of squares of each column totals 1)"
+    target_description = (
+        "Regression task predicting the quantitative measure of disease progression "
+        "one year after baselines"
+    )
+    norm_method = "mean centered and scaled by the standard deviation"
     feature_descriptions = [
-        {"name": "age", "type": "float", "description": f"Age in years ({norm_method})"},
-        {"name": "sex", "type": "float", "description": f"Sex of the patient ({norm_method})"},
-        {"name": "bmi", "type": "float", "description": f"Body mass index ({norm_method})"},
-        {"name": "bp", "type": "float", "description": f"Average Blood pressure ({norm_method})"},
-        {"name": "s1", "type": "float", "description": f"TC, total serum cholesterol ({norm_method})"},
-        {"name": "s2", "type": "float", "description": f"LDL, low-density lipoprotein ({norm_method})"},
-        {"name": "s3", "type": "float", "description": f"HDL, high-density lipoprotein ({norm_method})"},
-        {"name": "s4", "type": "float", "description": f"TCH, total cholesterol/HDL ratio ({norm_method})"},
-        {"name": "s5", "type": "float", "description": f"s5 ltg, possibly log of serum triglycerides level ({norm_method})"},
-        {"name": "s6", "type": "float", "description": f"s6 glu, blood sugar level ({norm_method})"},
+        {"name": "age", "type": "float64", "description": f"Age in years ({norm_method})"},
+        {"name": "sex", "type": "float64", "description": f"Sex of the patient ({norm_method})"},
+        {"name": "bmi", "type": "float64", "description": f"Body mass index ({norm_method})"},
+        {"name": "bp", "type": "float64", "description": f"Average blood pressure ({norm_method})"},
+        {"name": "s1", "type": "float64", "description": f"TC, total serum cholesterol ({norm_method})"},
+        {"name": "s2", "type": "float64", "description": f"LDL ({norm_method})"},
+        {"name": "s3", "type": "float64", "description": f"HDL ({norm_method})"},
+        {"name": "s4", "type": "float64", "description": f"TCH ratio ({norm_method})"},
+        {"name": "s5", "type": "float64", "description": f"s5 ltg, log serum triglycerides ({norm_method})"},
+        {"name": "s6", "type": "float64", "description": f"s6 glu, blood sugar ({norm_method})"},
     ]
 
-    llm_feature_engineer = LLMFeatureEngineer(y_col=target_column)
+    llm_feature_engineer = LLMFeatureEngineer(
+        problem_type="regression",
+        model_name="gpt-4o",
+        max_features=5,
+    )
 
-    # Fit the LLMFeatureEngineer
-    llm_feature_engineer.fit(X, y, feature_descriptions=feature_descriptions)
+    llm_feature_engineer.fit(
+        X=X,
+        feature_descriptions=feature_descriptions,
+        target_description=target_description,
+    )
 
-    # Transform the data
     X_transformed = llm_feature_engineer.transform(X)
-
     print(X_transformed.head())
     print(X_transformed.columns)
+
+
+Feature Evaluation
+------------------
+After fitting and transforming, you can evaluate the quality of generated features using mutual information (classification) or correlation (regression):
+
+.. code-block:: python
+
+    # After fit and transform
+    eval_results = llm_feature_engineer.evaluate_features(X, y, is_transformed=False)
+    print(eval_results)

--- a/docs/get_started.rst
+++ b/docs/get_started.rst
@@ -16,7 +16,7 @@ Please see the :doc:`installation` guide for step-by-step instructions on the pa
 
 Key Concepts
 ~~~~~~~~~~~~~~~~~~~
-``skfeaturellm`` is a Python library that brings the power of Large Language Models (LLMs) to feature engineering for tabular data, wrapped in a familiar scikit-learn–style API. The library aims to leverage LLMs' capabilities to automatically generate and implement meaningful features for your machine learning tasks.
+``skfeaturellm`` is a Python library that brings the power of Large Language Models (LLMs) to feature engineering for tabular data, wrapped in a familiar scikit-learn–style API. The library is **model-agnostic**: it works with any LLM available from LangChain (OpenAI, Anthropic, etc.). It leverages LLMs' capabilities to automatically generate and implement meaningful features for your machine learning tasks.
 
 
 Quickstart
@@ -25,33 +25,41 @@ The code snippets below are designed to introduce ``skfeaturellm``'s functionali
 
 Classification
 --------------
-Example applied to a classification task. The example uses the `Iris plants dataset <https://scikit-learn.org/stable/datasets/toy_dataset.html#iris-dataset>`_  from `sklearn.datasets`. The `LLMFeatureEngineer` class is then used to perform feature engineering on the dataset.
+Example applied to a classification task. The example uses the `Iris plants dataset <https://scikit-learn.org/stable/datasets/toy_dataset.html#iris-dataset>`_ from `sklearn.datasets`. The ``LLMFeatureEngineer`` class is then used to perform feature engineering on the dataset.
 
 .. code-block:: python
 
     from sklearn.datasets import load_iris
-    from skfeaturellm.feature_engineer import LLMFeatureEngineer
+    from skfeaturellm import LLMFeatureEngineer
 
     iris_data = load_iris(as_frame=True)
     X, y = iris_data.data, iris_data.target
 
-    target_column = (
+    target_description = (
         "Classification task predicting species of iris plants "
         "(3 classes: setosa, versicolor, virginica)"
     )
     feature_descriptions = [
-        {"name": "sepal length (cm)", "type": "float", "description": "The sepal lengths in centimeters"},
-        {"name": "sepal width (cm)", "type": "float", "description": "The sepal widths in centimeters"},
-        {"name": "petal length (cm)", "type": "float", "description": "The petal lengths in centimeters"},
-        {"name": "petal width (cm)", "type": "float", "description": "The petal widths in centimeters"},
+        {"name": "sepal length (cm)", "type": "float64", "description": "The sepal lengths in centimeters"},
+        {"name": "sepal width (cm)", "type": "float64", "description": "The sepal widths in centimeters"},
+        {"name": "petal length (cm)", "type": "float64", "description": "The petal lengths in centimeters"},
+        {"name": "petal width (cm)", "type": "float64", "description": "The petal widths in centimeters"},
     ]
 
-    llm_feature_engineer = LLMFeatureEngineer(y_col=target_column)
+    llm_feature_engineer = LLMFeatureEngineer(
+        problem_type="classification",
+        model_name="gpt-4o",
+        max_features=5,
+    )
 
-    # Fit the LLMFeatureEngineer
-    llm_feature_engineer.fit(X, y, feature_descriptions=feature_descriptions)
+    # Fit the LLMFeatureEngineer (uses LLM to generate feature ideas)
+    llm_feature_engineer.fit(
+        X=X,
+        feature_descriptions=feature_descriptions,
+        target_description=target_description,
+    )
 
-    # Transform the data
+    # Transform the data (apply generated transformations)
     X_transformed = llm_feature_engineer.transform(X)
 
     print(X_transformed.head())
@@ -60,35 +68,46 @@ Example applied to a classification task. The example uses the `Iris plants data
 
 Regression
 -----------
-Example applied to a regression task. The example uses the `Diabetes dataset <https://scikit-learn.org/stable/datasets/toy_dataset.html#diabetes-dataset>`_  from `sklearn.datasets`. The `LLMFeatureEngineer` class is then used to perform feature engineering on the dataset.
+Example applied to a regression task. The example uses the `Diabetes dataset <https://scikit-learn.org/stable/datasets/toy_dataset.html#diabetes-dataset>`_ from `sklearn.datasets`. The ``LLMFeatureEngineer`` class is then used to perform feature engineering on the dataset.
 
 .. code-block:: python
 
     from sklearn.datasets import load_diabetes
-    from skfeaturellm.feature_engineer import LLMFeatureEngineer
+    from skfeaturellm import LLMFeatureEngineer
 
     diabetes_data = load_diabetes(as_frame=True)
     X, y = diabetes_data.data, diabetes_data.target
 
-    target_column = "Regression task predicting the quantitative measure of disease progression one year after baselines"
-    norm_method = "mean centered and scaled by the standard deviation times the square root of n_samples (i.e. the sum of squares of each column totals 1)"
+    target_description = (
+        "Regression task predicting the quantitative measure of disease progression "
+        "one year after baselines"
+    )
+    norm_method = "mean centered and scaled by the standard deviation"
     feature_descriptions = [
-        {"name": "age", "type": "float", "description": f"Age in years ({norm_method})"},
-        {"name": "sex", "type": "float", "description": f"Sex of the patient ({norm_method})"},
-        {"name": "bmi", "type": "float", "description": f"Body mass index ({norm_method})"},
-        {"name": "bp", "type": "float", "description": f"Average Blood pressure ({norm_method})"},
-        {"name": "s1", "type": "float", "description": f"TC, total serum cholesterol ({norm_method})"},
-        {"name": "s2", "type": "float", "description": f"LDL, low-density lipoprotein ({norm_method})"},
-        {"name": "s3", "type": "float", "description": f"HDL, high-density lipoprotein ({norm_method})"},
-        {"name": "s4", "type": "float", "description": f"TCH, total cholesterol/HDL ratio ({norm_method})"},
-        {"name": "s5", "type": "float", "description": f"s5 ltg, possibly log of serum triglycerides level ({norm_method})"},
-        {"name": "s6", "type": "float", "description": f"s6 glu, blood sugar level ({norm_method})"},
+        {"name": "age", "type": "float64", "description": f"Age in years ({norm_method})"},
+        {"name": "sex", "type": "float64", "description": f"Sex of the patient ({norm_method})"},
+        {"name": "bmi", "type": "float64", "description": f"Body mass index ({norm_method})"},
+        {"name": "bp", "type": "float64", "description": f"Average blood pressure ({norm_method})"},
+        {"name": "s1", "type": "float64", "description": f"TC, total serum cholesterol ({norm_method})"},
+        {"name": "s2", "type": "float64", "description": f"LDL, low-density lipoprotein ({norm_method})"},
+        {"name": "s3", "type": "float64", "description": f"HDL, high-density lipoprotein ({norm_method})"},
+        {"name": "s4", "type": "float64", "description": f"TCH, total cholesterol/HDL ratio ({norm_method})"},
+        {"name": "s5", "type": "float64", "description": f"s5 ltg, possibly log of serum triglycerides ({norm_method})"},
+        {"name": "s6", "type": "float64", "description": f"s6 glu, blood sugar level ({norm_method})"},
     ]
 
-    llm_feature_engineer = LLMFeatureEngineer(y_col=target_column)
+    llm_feature_engineer = LLMFeatureEngineer(
+        problem_type="regression",
+        model_name="gpt-4o",
+        max_features=5,
+    )
 
     # Fit the LLMFeatureEngineer
-    llm_feature_engineer.fit(X, y, feature_descriptions=feature_descriptions)
+    llm_feature_engineer.fit(
+        X=X,
+        feature_descriptions=feature_descriptions,
+        target_description=target_description,
+    )
 
     # Transform the data
     X_transformed = llm_feature_engineer.transform(X)

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,7 +1,7 @@
 Welcome to skfeaturellm's documentation!
 ====================================
 
-skfeaturellm is a Python library that leverages Large Language Models (LLMs) for automated feature engineering in machine learning pipelines.
+skfeaturellm is a Python library that leverages Large Language Models (LLMs) for automated feature engineering in machine learning pipelines. It is model-agnostic and works with any LLM available from LangChain (OpenAI, Anthropic, etc.).
 
 .. toctree::
    :maxdepth: 2

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -50,7 +50,7 @@ To install from a specific branch, use the following command:
 Installing Full Developer Setup
 ~~~~~~~~~~~~~~~~~~~
 For whom:
-- contributors to the sktime project
+- contributors to the skfeaturellm project
 - developers of extensions in closed code bases
 - developers of 3rd party extensions released as open source
 

--- a/docs/user_guide.rst
+++ b/docs/user_guide.rst
@@ -2,3 +2,48 @@ User Guide
 ==========
 
 This guide provides an overview of how to use skfeaturellm for automated feature engineering.
+
+
+Overview
+--------
+``skfeaturellm`` uses Large Language Models (LLMs) to suggest meaningful feature transformations for tabular data. The LLM outputs ideas in a structured format (Feature Transformation DSL), which are then validated and executed safely—no ``eval()`` or raw code execution.
+
+
+Workflow
+--------
+1. **Fit**: Provide feature descriptions and target description; the LLM generates feature ideas.
+2. **Transform**: Execute the generated transformations on your data.
+3. **Evaluate** (optional): Assess feature quality with mutual information (classification) or correlation (regression).
+
+
+LLMFeatureEngineer Parameters
+-----------------------------
+
+- **problem_type**: ``"classification"`` or ``"regression"``
+- **model_name**: LLM model—any model available from LangChain (e.g., ``"gpt-4o"``, ``"gpt-4"`` for OpenAI; ``"claude-3-5-sonnet"`` for Anthropic; see `LangChain chat models <https://python.langchain.com/docs/integrations/chat/>`_)
+- **target_col**: Optional target column name (for future use)
+- **max_features**: Maximum number of features to generate
+- **feature_prefix**: Prefix for generated feature names (default: ``"llm_feat_"``)
+- **kwargs**: Passed to LangChain's ``init_chat_model`` (e.g., ``api_key``, ``temperature``, ``model_provider``)
+
+
+Feature Transformation DSL
+--------------------------
+The LLM generates ideas in a structured format with:
+
+- **type**: Transformation type (e.g., ``add``, ``div``, ``log``, ``pow``)
+- **feature_name**: Name for the new feature
+- **description**: Explanation of the feature
+- **columns**: List of column names (1 for unary, 1–2 for binary)
+- **parameters**: Optional parameters (e.g., ``{"constant": 2.0}`` for binary ops, ``{"power": 0.5}`` for pow)
+
+Supported transformations:
+
+**Binary** (column-column or column-constant): ``add``, ``sub``, ``mul``, ``div``
+
+**Unary**: ``log``, ``log1p``, ``abs``, ``exp``, ``pow``
+
+
+API Keys and Provider Configuration
+------------------------------------
+The library is **model-agnostic**: it works with any LLM provider supported by LangChain (OpenAI, Anthropic, etc.). Set the appropriate API key for your provider (e.g., ``OPENAI_API_KEY``, ``ANTHROPIC_API_KEY``) or pass ``api_key`` and ``model_provider`` to ``LLMFeatureEngineer`` via ``kwargs``. See `LangChain model setup <https://python.langchain.com/docs/integrations/chat/>`_ for provider-specific configuration.


### PR DESCRIPTION
- Align get_started and examples with current API (problem_type, target_description, fit signature)
- Expand user_guide with Feature Transformation DSL and workflow
- Add transformations, schemas, and reporting to API reference
- Clarify model-agnostic support for any LangChain LLM (OpenAI, Anthropic, etc.)
- Fix installation copy (skfeaturellm instead of sktime)
- Add feature evaluation example

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk because changes are documentation-only, primarily updating examples and API references; the main risk is confusing users if the documented API diverges from the actual implementation.
> 
> **Overview**
> Updates the documentation to reflect the current `LLMFeatureEngineer` API (new initialization params like `problem_type`/`model_name`, updated `fit` signature using `target_description`, and simplified imports via `from skfeaturellm import LLMFeatureEngineer`).
> 
> Expands docs to emphasize *model-agnostic* LangChain LLM support, adds a fuller `user_guide` describing the Feature Transformation DSL/workflow and provider configuration, extends the API reference to include `schemas`, `reporting`, and `transformations`, and adds a feature evaluation example plus a small installation text fix.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6b0dee2adc46807904703086c3b7ac144f2cd06a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->