### PR TITLE
Feature/expand transformations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -175,3 +175,6 @@ cython_debug/
 
 # PyPI configuration file
 .pypirc
+
+# Local planning docs
+ROADMAP.md

--- a/skfeaturellm/llm_interface.py
+++ b/skfeaturellm/llm_interface.py
@@ -13,7 +13,11 @@ from skfeaturellm.schemas import (
     FeatureDescriptions,
     FeatureEngineeringIdeas,
 )
-from skfeaturellm.transformations import get_transformation_types_for_prompt
+from skfeaturellm.transformations import (
+    get_binary_operation_types,
+    get_transformation_types_for_prompt,
+    get_unary_operation_types,
+)
 from skfeaturellm.types import ProblemType
 
 
@@ -154,6 +158,8 @@ class LLMInterface:
         )
 
         transformation_types = get_transformation_types_for_prompt()
+        unary_types = ", ".join(sorted(get_unary_operation_types()))
+        binary_types = ", ".join(sorted(get_binary_operation_types()))
 
         return {
             "feature_descriptions": feature_descriptions_schema.format(),
@@ -161,4 +167,6 @@ class LLMInterface:
             "target_description": target_description_message,
             "additional_context": additional_context,
             "transformation_types": transformation_types,
+            "unary_types": unary_types,
+            "binary_types": binary_types,
         }

--- a/skfeaturellm/prompts.py
+++ b/skfeaturellm/prompts.py
@@ -39,10 +39,10 @@ All transformations require:
 - description: A detailed explanation of what the feature represents and why it's useful
 - columns: A list of column names required for the transformation
 
-For UNARY operations (log, log1p, abs, exp, pow):
+For UNARY operations ({unary_types}):
 - columns: A list with exactly 1 column name
 
-For BINARY operations (add, sub, mul, div):
+For BINARY operations ({binary_types}):
 - columns: A list with 1 or 2 column names
   - For column-column operations: provide 2 column names
   - For column-constant operations: provide 1 column name + parameters with "constant"

--- a/skfeaturellm/schemas.py
+++ b/skfeaturellm/schemas.py
@@ -74,8 +74,9 @@ class TransformationParameters(BaseModel):
     """
     Parameters for transformations.
 
-    Used for OpenAI structured output compatibility (additionalProperties: false).
-    Explicitly defines allowed fields: constant for binary ops, power for pow op.
+    Used for structured output compatibility.
+    Explicitly defines allowed fields: constant for binary ops, power for pow op,
+    n_bins for bin op.
     """
 
     model_config = ConfigDict(extra="forbid")
@@ -87,6 +88,18 @@ class TransformationParameters(BaseModel):
     power: Optional[float] = Field(
         default=None,
         description="Power exponent for pow transformation",
+    )
+    n_bins: Optional[int] = Field(
+        default=None,
+        description="Number of equal-width bins for bin transformation (must be >= 2)",
+    )
+    bin_edges: Optional[List[float]] = Field(
+        default=None,
+        description=(
+            "Custom bin edges for bin transformation (e.g. [0, 50000, 100000, 200000]). "
+            "Use instead of n_bins when meaningful domain thresholds are known. "
+            "Must have at least 2 values."
+        ),
     )
 
 

--- a/skfeaturellm/transformations/__init__.py
+++ b/skfeaturellm/transformations/__init__.py
@@ -17,6 +17,8 @@ from skfeaturellm.transformations.binary import (
     BinaryArithmeticTransformation,
     DivisionByZeroError,
     DivTransformation,
+    MaxTransformation,
+    MinTransformation,
     MulTransformation,
     SubTransformation,
 )
@@ -39,6 +41,7 @@ from skfeaturellm.transformations.unary import (
     Log1pTransformation,
     LogTransformation,
     PowTransformation,
+    SqrtTransformation,
     UnaryTransformation,
 )
 
@@ -62,6 +65,8 @@ __all__ = [
     "SubTransformation",
     "MulTransformation",
     "DivTransformation",
+    "MaxTransformation",
+    "MinTransformation",
     "DivisionByZeroError",
     # Unary
     "UnaryTransformation",
@@ -70,5 +75,6 @@ __all__ = [
     "AbsTransformation",
     "ExpTransformation",
     "PowTransformation",
+    "SqrtTransformation",
     "InvalidValueError",
 ]

--- a/skfeaturellm/transformations/__init__.py
+++ b/skfeaturellm/transformations/__init__.py
@@ -36,6 +36,7 @@ from skfeaturellm.transformations.executor import (
 # Import unary transformations to trigger registration
 from skfeaturellm.transformations.unary import (
     AbsTransformation,
+    BinTransformation,
     ExpTransformation,
     InvalidValueError,
     Log1pTransformation,
@@ -76,5 +77,6 @@ __all__ = [
     "ExpTransformation",
     "PowTransformation",
     "SqrtTransformation",
+    "BinTransformation",
     "InvalidValueError",
 ]

--- a/skfeaturellm/transformations/binary/__init__.py
+++ b/skfeaturellm/transformations/binary/__init__.py
@@ -7,6 +7,8 @@ from skfeaturellm.transformations.binary.arithmetic import (
     BinaryArithmeticTransformation,
     DivisionByZeroError,
     DivTransformation,
+    MaxTransformation,
+    MinTransformation,
     MulTransformation,
     SubTransformation,
 )
@@ -17,5 +19,7 @@ __all__ = [
     "SubTransformation",
     "MulTransformation",
     "DivTransformation",
+    "MaxTransformation",
+    "MinTransformation",
     "DivisionByZeroError",
 ]

--- a/skfeaturellm/transformations/binary/arithmetic.py
+++ b/skfeaturellm/transformations/binary/arithmetic.py
@@ -5,6 +5,7 @@ Binary arithmetic transformations for feature engineering.
 from abc import abstractmethod
 from typing import Any, Dict, List, Optional, Set, Union
 
+import numpy as np
 import pandas as pd
 
 from skfeaturellm.transformations.base import (
@@ -201,3 +202,45 @@ class DivTransformation(BinaryArithmeticTransformation):
                 )
         elif right == 0:
             raise DivisionByZeroError("Division by zero: constant is 0")
+
+
+@register_transformation("max")
+class MaxTransformation(BinaryArithmeticTransformation):
+    """
+    Element-wise maximum transformation: max(left, right).
+
+    Examples
+    --------
+    >>> t = MaxTransformation("max_ab", columns=["a", "b"])
+    >>> t = MaxTransformation("at_least_zero", columns=["a"], parameters={"constant": 0.0})
+    """
+
+    @classmethod
+    def get_prompt_description(cls) -> str:
+        return "Element-wise maximum of two columns or a column and a constant"
+
+    def _apply_operation(
+        self, left: pd.Series, right: Union[pd.Series, float]
+    ) -> pd.Series:
+        return np.maximum(left, right)
+
+
+@register_transformation("min")
+class MinTransformation(BinaryArithmeticTransformation):
+    """
+    Element-wise minimum transformation: min(left, right).
+
+    Examples
+    --------
+    >>> t = MinTransformation("min_ab", columns=["a", "b"])
+    >>> t = MinTransformation("at_most_100", columns=["a"], parameters={"constant": 100.0})
+    """
+
+    @classmethod
+    def get_prompt_description(cls) -> str:
+        return "Element-wise minimum of two columns or a column and a constant"
+
+    def _apply_operation(
+        self, left: pd.Series, right: Union[pd.Series, float]
+    ) -> pd.Series:
+        return np.minimum(left, right)

--- a/skfeaturellm/transformations/unary/__init__.py
+++ b/skfeaturellm/transformations/unary/__init__.py
@@ -12,6 +12,7 @@ from skfeaturellm.transformations.unary.arithmetic import (
     SqrtTransformation,
     UnaryTransformation,
 )
+from skfeaturellm.transformations.unary.binning import BinTransformation
 
 __all__ = [
     "UnaryTransformation",
@@ -21,5 +22,6 @@ __all__ = [
     "ExpTransformation",
     "PowTransformation",
     "SqrtTransformation",
+    "BinTransformation",
     "InvalidValueError",
 ]

--- a/skfeaturellm/transformations/unary/__init__.py
+++ b/skfeaturellm/transformations/unary/__init__.py
@@ -9,6 +9,7 @@ from skfeaturellm.transformations.unary.arithmetic import (
     Log1pTransformation,
     LogTransformation,
     PowTransformation,
+    SqrtTransformation,
     UnaryTransformation,
 )
 
@@ -19,5 +20,6 @@ __all__ = [
     "AbsTransformation",
     "ExpTransformation",
     "PowTransformation",
+    "SqrtTransformation",
     "InvalidValueError",
 ]

--- a/skfeaturellm/transformations/unary/arithmetic.py
+++ b/skfeaturellm/transformations/unary/arithmetic.py
@@ -150,6 +150,30 @@ class ExpTransformation(UnaryTransformation):
         return np.exp(values)
 
 
+@register_transformation("sqrt")
+class SqrtTransformation(UnaryTransformation):
+    """
+    Square root transformation: sqrt(column).
+
+    Raises InvalidValueError if any values are < 0.
+
+    Examples
+    --------
+    >>> t = SqrtTransformation("sqrt_area", columns=["area"])
+    """
+
+    @classmethod
+    def get_prompt_description(cls) -> str:
+        return "Square root (sqrt(column)) - useful for right-skewed non-negative data"
+
+    def _apply_operation(self, values: pd.Series) -> pd.Series:
+        if (values < 0).any():
+            raise InvalidValueError(
+                f"Sqrt transformation requires all values >= 0 in column '{self._column}'"
+            )
+        return np.sqrt(values)
+
+
 @register_transformation("pow")
 class PowTransformation(UnaryTransformation):
     """

--- a/skfeaturellm/transformations/unary/binning.py
+++ b/skfeaturellm/transformations/unary/binning.py
@@ -1,0 +1,98 @@
+"""
+Unary binning (discretization) transformations for feature engineering.
+"""
+
+from typing import Any, Dict, List, Optional, Union
+
+import pandas as pd
+
+from skfeaturellm.transformations.base import TransformationError
+from skfeaturellm.transformations.executor import register_transformation
+from skfeaturellm.transformations.unary.arithmetic import UnaryTransformation
+
+
+@register_transformation("bin")
+class BinTransformation(UnaryTransformation):
+    """
+    Binning transformation: discretizes a continuous column into intervals,
+    returning string interval labels (e.g. "(0.5, 2.5]").
+
+    Supports two modes via parameters (exactly one must be provided):
+
+    - ``n_bins`` (int >= 2): equal-width bins computed from the data range.
+    - ``bin_edges`` (List[float]): custom bin edges for domain-specific thresholds
+      (e.g. ``[0, 50000, 100000, 200000]`` for income brackets).
+
+    Useful for converting continuous features into ordinal categories.
+
+    Note: output dtype is object (string). Downstream metrics that require
+    numerical input (e.g., Pearson/Spearman correlation) will not be computed
+    for this feature and will return NaN with a warning.
+
+    Parameters
+    ----------
+    feature_name : str
+        Name for the resulting feature
+    columns : List[str]
+        List with exactly one column name
+    parameters : Dict[str, Any]
+        Must contain exactly one of 'n_bins' (int >= 2) or
+        'bin_edges' (list of floats with at least 2 values)
+
+    Examples
+    --------
+    >>> t = BinTransformation("age_group", columns=["age"], parameters={"n_bins": 4})
+    >>> t = BinTransformation(
+    ...     "income_bracket",
+    ...     columns=["income"],
+    ...     parameters={"bin_edges": [0, 30000, 70000, 150000, 1000000]},
+    ... )
+    """
+
+    def __init__(
+        self,
+        feature_name: str,
+        columns: List[str],
+        parameters: Optional[Dict[str, Any]] = None,
+    ):
+        super().__init__(feature_name, columns, parameters)
+
+        n_bins = parameters.get("n_bins") if parameters else None
+        bin_edges = parameters.get("bin_edges") if parameters else None
+
+        if n_bins is None and bin_edges is None:
+            raise ValueError(
+                "BinTransformation requires either 'n_bins' or 'bin_edges' in parameters"
+            )
+        if n_bins is not None and bin_edges is not None:
+            raise ValueError(
+                "BinTransformation requires either 'n_bins' or 'bin_edges', not both"
+            )
+
+        if n_bins is not None:
+            n_bins = int(n_bins)
+            if n_bins < 2:
+                raise ValueError("'n_bins' must be an integer >= 2")
+            self._bins: Union[int, List[float]] = n_bins
+        else:
+            bin_edges = list(bin_edges)
+            if len(bin_edges) < 2:
+                raise ValueError("'bin_edges' must contain at least 2 values")
+            self._bins = bin_edges
+
+    @classmethod
+    def get_prompt_description(cls) -> str:
+        return (
+            "Binning - discretizes a continuous column into string interval labels. "
+            "Use 'n_bins' (int >= 2) for equal-width bins, "
+            "or 'bin_edges' (list of floats) for domain-specific thresholds "
+            "(e.g. [0, 50000, 100000, 200000] for income brackets)"
+        )
+
+    def _apply_operation(self, values: pd.Series) -> pd.Series:
+        try:
+            return pd.cut(values, bins=self._bins).astype(str)
+        except ValueError as e:
+            raise TransformationError(
+                f"Binning failed for column '{self._column}': {e}"
+            ) from e

--- a/tests/transformations/test_binary.py
+++ b/tests/transformations/test_binary.py
@@ -1,5 +1,6 @@
 """Tests for binary transformations."""
 
+import numpy as np
 import pytest
 
 from skfeaturellm.transformations import (
@@ -7,6 +8,8 @@ from skfeaturellm.transformations import (
     ColumnNotFoundError,
     DivisionByZeroError,
     DivTransformation,
+    MaxTransformation,
+    MinTransformation,
     MulTransformation,
     SubTransformation,
 )
@@ -133,6 +136,70 @@ def test_div_by_zero_constant(sample_df):
 
     with pytest.raises(DivisionByZeroError):
         t.execute(sample_df)
+
+
+# =============================================================================
+# Test: MaxTransformation
+# =============================================================================
+
+
+def test_max_two_columns(sample_df):
+    """Test element-wise maximum of two columns."""
+    t = MaxTransformation("max_ab", columns=["a", "b"])
+    result = t.execute(sample_df)
+
+    assert result.name == "max_ab"
+    expected = np.maximum([10, 20, 30, 40], [2, 4, 5, 8])
+    np.testing.assert_array_almost_equal(result, expected)
+
+
+def test_max_column_and_constant(sample_df):
+    """Test element-wise maximum of column and constant (lower-bound clamp)."""
+    t = MaxTransformation("at_least_15", columns=["a"], parameters={"constant": 15.0})
+    result = t.execute(sample_df)
+
+    assert result.name == "at_least_15"
+    expected = np.maximum([10, 20, 30, 40], 15.0)
+    np.testing.assert_array_almost_equal(result, expected)
+
+
+def test_max_get_prompt_description():
+    """Test get_prompt_description returns a string."""
+    desc = MaxTransformation.get_prompt_description()
+    assert isinstance(desc, str)
+    assert "max" in desc.lower()
+
+
+# =============================================================================
+# Test: MinTransformation
+# =============================================================================
+
+
+def test_min_two_columns(sample_df):
+    """Test element-wise minimum of two columns."""
+    t = MinTransformation("min_ab", columns=["a", "b"])
+    result = t.execute(sample_df)
+
+    assert result.name == "min_ab"
+    expected = np.minimum([10, 20, 30, 40], [2, 4, 5, 8])
+    np.testing.assert_array_almost_equal(result, expected)
+
+
+def test_min_column_and_constant(sample_df):
+    """Test element-wise minimum of column and constant (upper-bound clamp)."""
+    t = MinTransformation("at_most_25", columns=["a"], parameters={"constant": 25.0})
+    result = t.execute(sample_df)
+
+    assert result.name == "at_most_25"
+    expected = np.minimum([10, 20, 30, 40], 25.0)
+    np.testing.assert_array_almost_equal(result, expected)
+
+
+def test_min_get_prompt_description():
+    """Test get_prompt_description returns a string."""
+    desc = MinTransformation.get_prompt_description()
+    assert isinstance(desc, str)
+    assert "min" in desc.lower()
 
 
 # =============================================================================

--- a/tests/transformations/test_binning.py
+++ b/tests/transformations/test_binning.py
@@ -1,0 +1,137 @@
+"""Tests for binning (discretization) transformations."""
+
+import pytest
+
+from skfeaturellm.transformations import BinTransformation
+
+# =============================================================================
+# Test: BinTransformation — n_bins mode
+# =============================================================================
+
+
+def test_bin_transformation_output_type(sample_df):
+    """Test that bin produces a string (object dtype) Series."""
+    t = BinTransformation("bin_a", columns=["a"], parameters={"n_bins": 2})
+    result = t.execute(sample_df)
+
+    assert result.name == "bin_a"
+    assert result.dtype == object
+
+
+def test_bin_transformation_n_unique_equals_n_bins(sample_df):
+    """Test that the number of unique bin labels equals n_bins."""
+    t = BinTransformation("bin_a", columns=["a"], parameters={"n_bins": 2})
+    result = t.execute(sample_df)
+
+    assert len(result.unique()) == 2
+
+
+def test_bin_transformation_all_values_are_strings(sample_df):
+    """Test that all output values are strings."""
+    t = BinTransformation("bin_a", columns=["a"], parameters={"n_bins": 2})
+    result = t.execute(sample_df)
+
+    assert all(isinstance(v, str) for v in result)
+
+
+def test_bin_transformation_four_bins(sample_df):
+    """Test binning with n_bins=4 produces 4 unique labels."""
+    t = BinTransformation("bin_b", columns=["a"], parameters={"n_bins": 4})
+    result = t.execute(sample_df)
+
+    assert result.name == "bin_b"
+    assert len(result.unique()) == 4
+
+
+# =============================================================================
+# Test: BinTransformation — bin_edges mode
+# =============================================================================
+
+
+def test_bin_transformation_bin_edges_output_type(sample_df):
+    """Test that bin with custom edges produces a string (object dtype) Series."""
+    t = BinTransformation("bin_a", columns=["a"], parameters={"bin_edges": [0, 25, 50]})
+    result = t.execute(sample_df)
+
+    assert result.name == "bin_a"
+    assert result.dtype == object
+
+
+def test_bin_transformation_bin_edges_correct_labels(sample_df):
+    """Test that bin with custom edges assigns values to the correct intervals."""
+    # a = [10, 20, 30, 40]; edges [0, 25, 50] → two bins: (0, 25] and (25, 50]
+    t = BinTransformation("bin_a", columns=["a"], parameters={"bin_edges": [0, 25, 50]})
+    result = t.execute(sample_df)
+
+    assert len(result.unique()) == 2
+    # 10 and 20 fall in the lower bin, 30 and 40 in the upper bin
+    assert result[0] == result[1]  # 10 and 20 same bin
+    assert result[2] == result[3]  # 30 and 40 same bin
+    assert result[0] != result[2]  # different bins
+
+
+def test_bin_transformation_bin_edges_all_values_are_strings(sample_df):
+    """Test that custom bin edges produce string labels."""
+    t = BinTransformation("bin_a", columns=["a"], parameters={"bin_edges": [0, 25, 50]})
+    result = t.execute(sample_df)
+
+    assert all(isinstance(v, str) for v in result)
+
+
+# =============================================================================
+# Test: BinTransformation — common
+# =============================================================================
+
+
+def test_bin_transformation_get_required_columns():
+    """Test get_required_columns returns the single column."""
+    t = BinTransformation("bin_a", columns=["a"], parameters={"n_bins": 3})
+    assert t.get_required_columns() == {"a"}
+
+
+def test_bin_get_prompt_description():
+    """Test get_prompt_description mentions both modes."""
+    desc = BinTransformation.get_prompt_description()
+    assert isinstance(desc, str)
+    assert "bin" in desc.lower()
+    assert "n_bins" in desc
+    assert "bin_edges" in desc
+
+
+# =============================================================================
+# Test: BinTransformation — parameter validation
+# =============================================================================
+
+
+def test_bin_missing_parameters():
+    """Test that missing parameters raises ValueError."""
+    with pytest.raises(ValueError, match="requires either 'n_bins' or 'bin_edges'"):
+        BinTransformation("bin_a", columns=["a"])
+
+
+def test_bin_missing_both_params():
+    """Test that parameters with neither n_bins nor bin_edges raises ValueError."""
+    with pytest.raises(ValueError, match="requires either 'n_bins' or 'bin_edges'"):
+        BinTransformation("bin_a", columns=["a"], parameters={"constant": 5.0})
+
+
+def test_bin_both_params_raises():
+    """Test that providing both n_bins and bin_edges raises ValueError."""
+    with pytest.raises(ValueError, match="not both"):
+        BinTransformation(
+            "bin_a",
+            columns=["a"],
+            parameters={"n_bins": 3, "bin_edges": [0, 10, 20, 30]},
+        )
+
+
+def test_bin_n_bins_too_small():
+    """Test that n_bins < 2 raises ValueError."""
+    with pytest.raises(ValueError, match="'n_bins' must be an integer >= 2"):
+        BinTransformation("bin_a", columns=["a"], parameters={"n_bins": 1})
+
+
+def test_bin_edges_too_few():
+    """Test that bin_edges with fewer than 2 values raises ValueError."""
+    with pytest.raises(ValueError, match="'bin_edges' must contain at least 2 values"):
+        BinTransformation("bin_a", columns=["a"], parameters={"bin_edges": [10.0]})

--- a/tests/transformations/test_executor.py
+++ b/tests/transformations/test_executor.py
@@ -303,6 +303,8 @@ def test_get_registered_transformations():
     assert "sub" in registry
     assert "mul" in registry
     assert "div" in registry
+    assert "max" in registry
+    assert "min" in registry
 
     # Unary operations
     assert "log" in registry
@@ -310,8 +312,9 @@ def test_get_registered_transformations():
     assert "pow" in registry
     assert "abs" in registry
     assert "exp" in registry
+    assert "sqrt" in registry
 
-    assert len(registry) == 9
+    assert len(registry) == 12
 
 
 def test_get_transformation_types_for_prompt():

--- a/tests/transformations/test_executor.py
+++ b/tests/transformations/test_executor.py
@@ -313,8 +313,9 @@ def test_get_registered_transformations():
     assert "abs" in registry
     assert "exp" in registry
     assert "sqrt" in registry
+    assert "bin" in registry
 
-    assert len(registry) == 12
+    assert len(registry) == 13
 
 
 def test_get_transformation_types_for_prompt():

--- a/tests/transformations/test_unary.py
+++ b/tests/transformations/test_unary.py
@@ -10,6 +10,7 @@ from skfeaturellm.transformations import (
     Log1pTransformation,
     LogTransformation,
     PowTransformation,
+    SqrtTransformation,
 )
 
 # =============================================================================
@@ -171,6 +172,46 @@ def test_exp_transformation(sample_df):
     assert result.name == "exp_positive"
     expected = np.exp([1.0, 2.0, 3.0, 4.0])
     np.testing.assert_array_almost_equal(result, expected)
+
+
+# =============================================================================
+# Test: SqrtTransformation
+# =============================================================================
+
+
+def test_sqrt_transformation(sample_df):
+    """Test sqrt transformation on non-negative values."""
+    t = SqrtTransformation("sqrt_positive", columns=["positive"])
+    result = t.execute(sample_df)
+
+    assert result.name == "sqrt_positive"
+    expected = np.sqrt([1.0, 2.0, 3.0, 4.0])
+    np.testing.assert_array_almost_equal(result, expected)
+
+
+def test_sqrt_transformation_zero(sample_df):
+    """Test that sqrt of zero is valid (returns 0)."""
+    t = SqrtTransformation("sqrt_zero", columns=["with_zero"])
+    result = t.execute(sample_df)
+
+    assert result.name == "sqrt_zero"
+    expected = np.sqrt([0, 1, 2, 3])
+    np.testing.assert_array_almost_equal(result, expected)
+
+
+def test_sqrt_transformation_negative_values(sample_df):
+    """Test that sqrt transformation raises error for negative values."""
+    t = SqrtTransformation("sqrt_negative", columns=["with_negative"])
+
+    with pytest.raises(InvalidValueError, match="all values >= 0"):
+        t.execute(sample_df)
+
+
+def test_sqrt_get_prompt_description():
+    """Test get_prompt_description returns a string."""
+    desc = SqrtTransformation.get_prompt_description()
+    assert isinstance(desc, str)
+    assert "sqrt" in desc.lower()
 
 
 # =============================================================================


### PR DESCRIPTION
### Summary
Expands the transformation registry with 4 new operations and fixes the LLM prompt to stay in sync with the registry automatically.

### New transformations
`sqrt` (unary) — square root via np.sqrt; raises InvalidValueError on negative input
`max` (binary) — element-wise maximum of two columns or a column and a constant (np.maximum)
`min` (binary) — element-wise minimum of two columns or a column and a constant (np.minimum)
bin` (unary, new module unary/binning.py) — discretizes a continuous column into string interval labels via pd.cut. Supports two mutually exclusive modes:
`n_bins` (int ≥ 2) for equal-width bins
`bin_edges` (List[float], ≥ 2 values) for domain-specific thresholds

### Schema changes (schemas.py)
TransformationParameters gains two new optional fields to support bin:
`n_bins: Optional[int]`
`bin_edges: Optional[List[float]]`

### Prompt fix (prompts.py + llm_interface.py)
The `FEATURE_ENGINEERING_PROMPT` previously hardcoded the unary/binary operation lists. These are now {unary_types} / {binary_types} template variables populated at runtime from `get_unary_operation_types()` / `get_binary_operation_types()`, so any future transformation added to the registry is automatically reflected in the LLM prompt.