### PR TITLE
feat(feature_engineer): add save() and load() for persistence

### DIFF
--- a/skfeaturellm/feature_engineer.py
+++ b/skfeaturellm/feature_engineer.py
@@ -2,6 +2,7 @@
 Main module for LLM-powered feature engineering.
 """
 
+import json
 import warnings
 from typing import Any, Dict, List, Optional
 
@@ -136,6 +137,66 @@ class LLMFeatureEngineer(BaseEstimator, TransformerMixin):
         ]
 
         return result_df
+
+    def save(self, path: str) -> None:
+        """
+        Serialize generated_features_ideas to a JSON file.
+
+        Parameters
+        ----------
+        path : str
+            Destination file path (e.g. "features_v1.json")
+
+        Raises
+        ------
+        ValueError
+            If fit() has not been called yet.
+        """
+        if not hasattr(self, "generated_features_ideas"):
+            raise ValueError("fit must be called before save")
+
+        data = {
+            "params": {
+                "problem_type": self.problem_type.value,
+                "model_name": self.model_name,
+                "target_col": self.target_col,
+                "max_features": self.max_features,
+                "feature_prefix": self.feature_prefix,
+            },
+            "generated_features_ideas": [
+                idea.model_dump() for idea in self.generated_features_ideas
+            ],
+        }
+        with open(path, "w", encoding="utf-8") as f:
+            json.dump(data, f, indent=2)
+
+    @classmethod
+    def load(cls, path: str) -> "LLMFeatureEngineer":
+        """
+        Restore an LLMFeatureEngineer from a JSON file produced by save().
+
+        The returned engineer has generated_features_ideas populated so that
+        transform() can be called immediately without fit().
+
+        Parameters
+        ----------
+        path : str
+            Path to the JSON file written by save().
+
+        Returns
+        -------
+        LLMFeatureEngineer
+            Restored engineer instance.
+        """
+        with open(path, "r", encoding="utf-8") as f:
+            data = json.load(f)
+
+        engineer = cls(**data["params"])
+        engineer.generated_features_ideas = [
+            FeatureEngineeringIdea.model_validate(idea)
+            for idea in data["generated_features_ideas"]
+        ]
+        return engineer
 
     def _build_executor_config(
         self, ideas: List[Any]

--- a/tests/test_feature_engineer.py
+++ b/tests/test_feature_engineer.py
@@ -1,5 +1,6 @@
 """Tests for the LLMFeatureEngineer class."""
 
+import json
 import warnings
 from unittest.mock import Mock
 
@@ -318,3 +319,79 @@ def test_evaluate_features_is_transformed_true(
     engineer.evaluate_features(X_with_feature, y, is_transformed=True)
 
     transform_spy.assert_not_called()
+
+
+def test_save_without_fit_raises(mocker, tmp_path):
+    """Test that save() raises ValueError if fit has not been called."""
+    mocker.patch("skfeaturellm.llm_interface.init_chat_model")
+    engineer = LLMFeatureEngineer(
+        problem_type="classification", model_name="gpt-4o", model_provider="openai"
+    )
+    with pytest.raises(ValueError, match="fit must be called before save"):
+        engineer.save(str(tmp_path / "features.json"))
+
+
+def test_save_and_load_roundtrip(mocker, tmp_path, sample_data_frame):
+    """Test that save() and load() round-trip generated_features_ideas correctly."""
+    mocker.patch("skfeaturellm.llm_interface.init_chat_model")
+
+    idea = FeatureEngineeringIdea(
+        type="mul",
+        feature_name="age_double",
+        columns=["age"],
+        parameters={"constant": 2.0},
+        description="Double the age",
+    )
+    engineer = LLMFeatureEngineer(
+        problem_type="classification",
+        model_name="gpt-4o",
+        target_col="label",
+        max_features=5,
+        feature_prefix="feat_",
+    )
+    engineer.generated_features_ideas = [idea]
+
+    save_path = str(tmp_path / "features.json")
+    engineer.save(save_path)
+
+    # Verify file contents
+    with open(save_path, encoding="utf-8") as f:
+        raw = json.load(f)
+    assert raw["params"]["problem_type"] == "classification"
+    assert raw["params"]["feature_prefix"] == "feat_"
+    assert len(raw["generated_features_ideas"]) == 1
+
+    # Restore and verify
+    loaded = LLMFeatureEngineer.load(save_path)
+    assert loaded.problem_type.value == "classification"
+    assert loaded.feature_prefix == "feat_"
+    assert loaded.target_col == "label"
+    assert loaded.max_features == 5
+    assert len(loaded.generated_features_ideas) == 1
+    assert loaded.generated_features_ideas[0].feature_name == "age_double"
+
+
+def test_load_allows_transform_without_fit(mocker, tmp_path, sample_data_frame):
+    """Test that a loaded engineer can call transform() without fit()."""
+    mocker.patch("skfeaturellm.llm_interface.init_chat_model")
+
+    idea = FeatureEngineeringIdea(
+        type="mul",
+        feature_name="age_double",
+        columns=["age"],
+        parameters={"constant": 2.0},
+        description="Double the age",
+    )
+    engineer = LLMFeatureEngineer(
+        problem_type="regression", model_name="gpt-4o", feature_prefix="llm_feat_"
+    )
+    engineer.generated_features_ideas = [idea]
+
+    save_path = str(tmp_path / "features.json")
+    engineer.save(save_path)
+
+    loaded = LLMFeatureEngineer.load(save_path)
+    result = loaded.transform(sample_data_frame)
+
+    assert "llm_feat_age_double" in result.columns
+    assert result["llm_feat_age_double"].tolist() == [50.0, 60.0]


### PR DESCRIPTION
Adds two methods to LLMFeatureEngineer so generated ideas can be serialized to JSON after fit() and restored without a new LLM call:
- save(path): writes params + generated_features_ideas to JSON
- load(path): classmethod that reconstructs the engineer and populates generated_features_ideas so transform() can be called immediately

Three tests cover the guard, round-trip correctness, and the load→transform flow.