### PR TITLE
Feature/add dataset stats to prompt

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -25,6 +25,34 @@ files = [
 ]
 
 [[package]]
+name = "anthropic"
+version = "0.84.0"
+description = "The official Python library for the anthropic API"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+files = [
+    {file = "anthropic-0.84.0-py3-none-any.whl", hash = "sha256:861c4c50f91ca45f942e091d83b60530ad6d4f98733bfe648065364da05d29e7"},
+    {file = "anthropic-0.84.0.tar.gz", hash = "sha256:72f5f90e5aebe62dca316cb013629cfa24996b0f5a4593b8c3d712bc03c43c37"},
+]
+
+[package.dependencies]
+anyio = ">=3.5.0,<5"
+distro = ">=1.7.0,<2"
+docstring-parser = ">=0.15,<1"
+httpx = ">=0.25.0,<1"
+jiter = ">=0.4.0,<1"
+pydantic = ">=1.9.0,<3"
+sniffio = "*"
+typing-extensions = ">=4.10,<5"
+
+[package.extras]
+aiohttp = ["aiohttp", "httpx-aiohttp (>=0.1.9)"]
+bedrock = ["boto3 (>=1.28.57)", "botocore (>=1.31.57)"]
+mcp = ["mcp (>=1.0) ; python_version >= \"3.10\""]
+vertex = ["google-auth[requests] (>=2,<3)"]
+
+[[package]]
 name = "anyio"
 version = "4.9.0"
 description = "High level compatibility layer for multiple asynchronous event loop implementations"
@@ -590,7 +618,7 @@ files = [
     {file = "colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6"},
     {file = "colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44"},
 ]
-markers = {main = "platform_system == \"Windows\"", dev = "sys_platform == \"win32\" or platform_system == \"Windows\""}
+markers = {main = "platform_system == \"Windows\"", dev = "platform_system == \"Windows\" or sys_platform == \"win32\""}
 
 [[package]]
 name = "comm"
@@ -1015,6 +1043,23 @@ files = [
     {file = "distro-1.9.0-py3-none-any.whl", hash = "sha256:7bffd925d65168f85027d8da9af6bddab658135b840670a223589bc0c8ef02b2"},
     {file = "distro-1.9.0.tar.gz", hash = "sha256:2fa77c6fd8940f116ee1d6b94a2f90b13b5ea8d019b98bc8bafdcabcdd9bdbed"},
 ]
+
+[[package]]
+name = "docstring-parser"
+version = "0.17.0"
+description = "Parse Python docstrings in reST, Google and Numpydoc format"
+optional = false
+python-versions = ">=3.8"
+groups = ["main"]
+files = [
+    {file = "docstring_parser-0.17.0-py3-none-any.whl", hash = "sha256:cf2569abd23dce8099b300f9b4fa8191e9582dda731fd533daf54c4551658708"},
+    {file = "docstring_parser-0.17.0.tar.gz", hash = "sha256:583de4a309722b3315439bb31d64ba3eebada841f2e2cee23b99df001434c912"},
+]
+
+[package.extras]
+dev = ["pre-commit (>=2.16.0) ; python_version >= \"3.9\"", "pydoctor (>=25.4.0)", "pytest"]
+docs = ["pydoctor (>=25.4.0)"]
+test = ["pytest"]
 
 [[package]]
 name = "docutils"
@@ -2057,6 +2102,47 @@ files = [
 ]
 
 [[package]]
+name = "kagglehub"
+version = "1.0.0"
+description = "Access Kaggle resources anywhere"
+optional = false
+python-versions = ">=3.10"
+groups = ["dev"]
+files = [
+    {file = "kagglehub-1.0.0-py3-none-any.whl", hash = "sha256:9397f0c6af04cdefa6fa8734c31b42863e8741aad5832c6f3af52f1ecf8fe509"},
+    {file = "kagglehub-1.0.0.tar.gz", hash = "sha256:21dc25d0279e2071f8b97cd9e1393d003ea5e054ea48f1e8139a39e4771e9a8d"},
+]
+
+[package.dependencies]
+kagglesdk = ">=0.1.14,<1.0"
+packaging = "*"
+pyyaml = "*"
+requests = "*"
+tqdm = "*"
+
+[package.extras]
+hf-datasets = ["datasets", "pandas"]
+pandas-datasets = ["pandas"]
+polars-datasets = ["polars"]
+signing = ["betterproto (>=2.0.0b6)", "model-signing", "sigstore (>=3.6.1)"]
+
+[[package]]
+name = "kagglesdk"
+version = "0.1.16"
+description = "Bindings to access kaggle's external-facing APIs"
+optional = false
+python-versions = ">=3.9"
+groups = ["dev"]
+files = [
+    {file = "kagglesdk-0.1.16-py3-none-any.whl", hash = "sha256:a26ba7a754866f8eef1e327e78101f2960b6fe9b1b323183f2f61170abdb11ff"},
+    {file = "kagglesdk-0.1.16.tar.gz", hash = "sha256:4a20da4ac6f4085e64b976a313ee136d4698737dc5be7c0f13009fadd41d5540"},
+]
+
+[package.dependencies]
+protobuf = "*"
+requests = "*"
+
+[[package]]
 name = "kiwisolver"
 version = "1.4.9"
 description = "A fast implementation of the Cassowary constraint solver"
@@ -2203,6 +2289,23 @@ together = ["langchain-together"]
 xai = ["langchain-xai"]
 
 [[package]]
+name = "langchain-anthropic"
+version = "1.3.4"
+description = "Integration package connecting Claude (Anthropic) APIs and LangChain"
+optional = false
+python-versions = "<4.0.0,>=3.10.0"
+groups = ["main"]
+files = [
+    {file = "langchain_anthropic-1.3.4-py3-none-any.whl", hash = "sha256:cd112dcc8049aef09f58b3c4338b2c9db5ee98105e08664954a4e40d8bf120b9"},
+    {file = "langchain_anthropic-1.3.4.tar.gz", hash = "sha256:000ed4c2d6fb8842b4ffeed22a74a3e84f9e9bcb63638e4abbb4a1d8ffa07211"},
+]
+
+[package.dependencies]
+anthropic = ">=0.78.0,<1.0.0"
+langchain-core = ">=1.2.15,<2.0.0"
+pydantic = ">=2.7.4,<3.0.0"
+
+[[package]]
 name = "langchain-classic"
 version = "1.0.1"
 description = "Building applications with LLMs through composability"
@@ -2242,14 +2345,14 @@ xai = ["langchain-xai"]
 
 [[package]]
 name = "langchain-core"
-version = "1.2.13"
+version = "1.2.17"
 description = "Building applications with LLMs through composability"
 optional = false
 python-versions = "<4.0.0,>=3.10.0"
 groups = ["main"]
 files = [
-    {file = "langchain_core-1.2.13-py3-none-any.whl", hash = "sha256:b31823e28d3eff1e237096d0bd3bf80c6f9624eb471a9496dbfbd427779f8d82"},
-    {file = "langchain_core-1.2.13.tar.gz", hash = "sha256:d2773d0d0130a356378db9a858cfeef64c3d64bc03722f1d4d6c40eb46fdf01b"},
+    {file = "langchain_core-1.2.17-py3-none-any.whl", hash = "sha256:bf6bd6ce503874e9c2da1669a69383e967c3de1ea808921d19a9a6bff1a9fbbe"},
+    {file = "langchain_core-1.2.17.tar.gz", hash = "sha256:54aa267f3311e347fb2e50951fe08e53761cebfb999ab80e6748d70525bbe872"},
 ]
 
 [package.dependencies]
@@ -3416,6 +3519,24 @@ files = [
 
 [package.dependencies]
 wcwidth = "*"
+
+[[package]]
+name = "protobuf"
+version = "7.34.0"
+description = ""
+optional = false
+python-versions = ">=3.10"
+groups = ["dev"]
+files = [
+    {file = "protobuf-7.34.0-cp310-abi3-macosx_10_9_universal2.whl", hash = "sha256:8e329966799f2c271d5e05e236459fe1cbfdb8755aaa3b0914fa60947ddea408"},
+    {file = "protobuf-7.34.0-cp310-abi3-manylinux2014_aarch64.whl", hash = "sha256:9d7a5005fb96f3c1e64f397f91500b0eb371b28da81296ae73a6b08a5b76cdd6"},
+    {file = "protobuf-7.34.0-cp310-abi3-manylinux2014_s390x.whl", hash = "sha256:4a72a8ec94e7a9f7ef7fe818ed26d073305f347f8b3b5ba31e22f81fd85fca02"},
+    {file = "protobuf-7.34.0-cp310-abi3-manylinux2014_x86_64.whl", hash = "sha256:964cf977e07f479c0697964e83deda72bcbc75c3badab506fb061b352d991b01"},
+    {file = "protobuf-7.34.0-cp310-abi3-win32.whl", hash = "sha256:f791ec509707a1d91bd02e07df157e75e4fb9fbdad12a81b7396201ec244e2e3"},
+    {file = "protobuf-7.34.0-cp310-abi3-win_amd64.whl", hash = "sha256:9f9079f1dde4e32342ecbd1c118d76367090d4aaa19da78230c38101c5b3dd40"},
+    {file = "protobuf-7.34.0-py3-none-any.whl", hash = "sha256:e3b914dd77fa33fa06ab2baa97937746ab25695f389869afdf03e81f34e45dc7"},
+    {file = "protobuf-7.34.0.tar.gz", hash = "sha256:3871a3df67c710aaf7bb8d214cc997342e63ceebd940c8c7fc65c9b3d697591a"},
+]
 
 [[package]]
 name = "psutil"
@@ -5106,7 +5227,7 @@ version = "4.67.1"
 description = "Fast, Extensible Progress Meter"
 optional = false
 python-versions = ">=3.7"
-groups = ["main"]
+groups = ["main", "dev"]
 files = [
     {file = "tqdm-4.67.1-py3-none-any.whl", hash = "sha256:26445eca388f82e72884e0d580d5464cd801a3ea01e63e5601bdff9ba6a48de2"},
     {file = "tqdm-4.67.1.tar.gz", hash = "sha256:f8aef9c52c08c13a65f30ea34f4e5aac3fd1a34959879d7e59e63027286627f2"},
@@ -5609,4 +5730,4 @@ docs = []
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.10"
-content-hash = "bac117826901661b2ddb8103b48e9bfcf7b0ed148cfcce7ed5078d3607842982"
+content-hash = "66aa3bca5e674c174cd20db974c7252c88bcf326ee526a3c0898d6e20a210c13"

--- a/poetry.lock
+++ b/poetry.lock
@@ -4893,6 +4893,21 @@ pure-eval = "*"
 tests = ["cython", "littleutils", "pygments", "pytest", "typeguard"]
 
 [[package]]
+name = "tabulate"
+version = "0.9.0"
+description = "Pretty-print tabular data"
+optional = false
+python-versions = ">=3.7"
+groups = ["main"]
+files = [
+    {file = "tabulate-0.9.0-py3-none-any.whl", hash = "sha256:024ca478df22e9340661486f85298cff5f6dcdba14f3813e8830015b9ed1948f"},
+    {file = "tabulate-0.9.0.tar.gz", hash = "sha256:0095b12bf5966de529c0feb1fa08671671b3368eec77d7ef7ab114be2c068b3c"},
+]
+
+[package.extras]
+widechars = ["wcwidth"]
+
+[[package]]
 name = "tenacity"
 version = "9.1.2"
 description = "Retry code until it succeeds"
@@ -5594,4 +5609,4 @@ docs = []
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.10"
-content-hash = "2664b0ed9603ebdc40c45f313ac07ca2ac29c0a7f32b690283be2c39fe677d43"
+content-hash = "bac117826901661b2ddb8103b48e9bfcf7b0ed148cfcce7ed5078d3607842982"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ langchain-openai = "^0.3.14"
 langchain-classic = "^1.0.1"
 matplotlib = "^3.10.8"
 tabulate = "^0.9.0"
+langchain-anthropic = "^1.3.4"
 
 [tool.poetry.extras]
 docs = [
@@ -52,6 +53,7 @@ sphinx-autodoc-typehints = "^1.25.2"
 nbsphinx = "^0.9.3"
 jupyter = "^1.1.1"
 pytest-cov = "^7.0.0"
+kagglehub = "^1.0.0"
 
 [tool.black]
 line-length = 88

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ langchain = "^1.0.0"
 langchain-openai = "^0.3.14"
 langchain-classic = "^1.0.1"
 matplotlib = "^3.10.8"
+tabulate = "^0.9.0"
 
 [tool.poetry.extras]
 docs = [

--- a/skfeaturellm/feature_engineer.py
+++ b/skfeaturellm/feature_engineer.py
@@ -57,6 +57,7 @@ class LLMFeatureEngineer(BaseEstimator, TransformerMixin):
     def fit(
         self,
         X: pd.DataFrame,
+        y: Optional[pd.Series] = None,
         feature_descriptions: Optional[List[Dict[str, Any]]] = None,
         target_description: Optional[str] = None,
     ) -> "LLMFeatureEngineer":
@@ -67,6 +68,8 @@ class LLMFeatureEngineer(BaseEstimator, TransformerMixin):
         ----------
         X : pd.DataFrame
             Input features
+        y : Optional[pd.Series]
+            Target variable used to compute dataset statistics for the prompt
         feature_descriptions : Optional[List[Dict[str, Any]]]
             List of feature descriptions
         target_description : Optional[str]
@@ -84,12 +87,17 @@ class LLMFeatureEngineer(BaseEstimator, TransformerMixin):
                 for col in X.columns
             ]
 
+        dataset_statistics = LLMInterface._format_dataset_statistics(
+            X, y, self.problem_type
+        )
+
         # Generate feature engineering ideas
         self.generated_features_ideas = self.llm_interface.generate_engineered_features(
             feature_descriptions=feature_descriptions,
             problem_type=self.problem_type.value,
             target_description=target_description,
             max_features=self.max_features,
+            dataset_statistics=dataset_statistics,
         ).ideas
 
         return self

--- a/skfeaturellm/llm_interface.py
+++ b/skfeaturellm/llm_interface.py
@@ -63,6 +63,7 @@ class LLMInterface:
         target_description: Optional[str] = None,
         max_features: Optional[int] = None,
         problem_type: Optional[ProblemType] = None,
+        dataset_statistics: Optional[str] = None,
     ) -> FeatureEngineeringIdeas:
         """
         Generate feature engineering ideas.
@@ -75,6 +76,8 @@ class LLMInterface:
             Description of the target variable and task
         max_features : Optional[int]
             Maximum number of features to generate
+        dataset_statistics : Optional[str]
+            Pre-formatted dataset statistics string from _format_dataset_statistics
 
         Returns
         -------
@@ -87,6 +90,7 @@ class LLMInterface:
             target_description=target_description,
             problem_type=problem_type,
             max_features=max_features,
+            dataset_statistics=dataset_statistics,
         )
 
         return self.chain.invoke(prompt_context)
@@ -119,6 +123,7 @@ class LLMInterface:
         target_description: Optional[str] = None,
         max_features: Optional[int] = None,
         problem_type: Optional[ProblemType] = None,
+        dataset_statistics: Optional[str] = None,
     ) -> str:
         """
         Generate the prompt for the LLM.
@@ -131,6 +136,8 @@ class LLMInterface:
             Description of the target variable and task
         max_features : Optional[int]
             Maximum number of features to generate
+        dataset_statistics : Optional[str]
+            Pre-formatted dataset statistics string from _format_dataset_statistics
 
         Returns
         -------
@@ -162,10 +169,15 @@ class LLMInterface:
         unary_types = ", ".join(sorted(get_unary_operation_types()))
         binary_types = ", ".join(sorted(get_binary_operation_types()))
 
+        dataset_statistics_message = (
+            dataset_statistics if dataset_statistics is not None else "Not provided."
+        )
+
         return {
             "feature_descriptions": feature_descriptions_schema.format(),
             "problem_type": problem_type_message,
             "target_description": target_description_message,
+            "dataset_statistics": dataset_statistics_message,
             "additional_context": additional_context,
             "transformation_types": transformation_types,
             "unary_types": unary_types,

--- a/skfeaturellm/llm_interface.py
+++ b/skfeaturellm/llm_interface.py
@@ -4,6 +4,7 @@ Module for handling interactions with Language Models.
 
 from typing import Dict, List, Optional
 
+import pandas as pd
 from langchain.chat_models import init_chat_model
 from langchain_core.prompts import ChatPromptTemplate
 
@@ -170,3 +171,53 @@ class LLMInterface:
             "unary_types": unary_types,
             "binary_types": binary_types,
         }
+
+    @staticmethod
+    def _format_dataset_statistics(
+        X: pd.DataFrame,
+        y: Optional[pd.Series],
+        problem_type: Optional[ProblemType],
+    ) -> str:
+        """Format dataset statistics as human-readable text for the LLM prompt."""
+        lines: List[str] = []
+
+        # Target statistics
+        lines.append("Target statistics:")
+        if y is None:
+            lines.append("  Not provided.")
+        elif problem_type == ProblemType.REGRESSION:
+            lines.append(
+                f"  min={y.min():.4g}, max={y.max():.4g}, "
+                f"mean={y.mean():.4g}, std={y.std():.4g}"
+            )
+        else:
+            counts = y.value_counts()
+            total = len(y)
+            for label, count in counts.items():
+                pct = 100.0 * count / total
+                lines.append(f"  class '{label}': {count} samples ({pct:.1f}%)")
+
+        lines.append("")
+
+        # Feature statistics — numeric columns only
+        numeric_cols = X.select_dtypes(include="number").columns.tolist()
+        lines.append("Feature statistics (numeric columns):")
+        if not numeric_cols:
+            lines.append("  No numeric features.")
+        else:
+            stats = X[numeric_cols].describe()
+            stats.loc["skewness"] = X[numeric_cols].skew()
+            lines.append(stats.T.to_markdown(floatfmt=".4g"))
+
+        # Feature statistics vs target
+        if y is not None and numeric_cols:
+            lines.append("")
+            lines.append("Feature statistics vs target:")
+            if problem_type == ProblemType.REGRESSION:
+                corr_df = X[numeric_cols].corrwith(y).to_frame(name="pearson_corr")
+                lines.append(corr_df.to_markdown(floatfmt=".4g"))
+            else:
+                grouped = X.groupby(y)[numeric_cols].mean().T
+                lines.append(grouped.to_markdown(floatfmt=".4g"))
+
+        return "\n".join(lines)

--- a/skfeaturellm/prompts.py
+++ b/skfeaturellm/prompts.py
@@ -16,6 +16,9 @@ Problem Type:
 Target Description:
 {target_description}
 
+Dataset Statistics:
+{dataset_statistics}
+
 Additional Context:
 {additional_context}
 

--- a/tests/test_feature_engineer.py
+++ b/tests/test_feature_engineer.py
@@ -395,3 +395,45 @@ def test_load_allows_transform_without_fit(mocker, tmp_path, sample_data_frame):
 
     assert "llm_feat_age_double" in result.columns
     assert result["llm_feat_age_double"].tolist() == [50.0, 60.0]
+
+
+def test_fit_passes_dataset_statistics_to_llm(
+    mocker, sample_data_frame
+):  # pylint: disable=redefined-outer-name
+    """fit() with y computes statistics and forwards them to generate_engineered_features."""
+    mock_ideas = Mock()
+    mock_ideas.ideas = []
+    mock_generate = mocker.patch(
+        "skfeaturellm.llm_interface.LLMInterface.generate_engineered_features",
+        return_value=mock_ideas,
+    )
+    mocker.patch("skfeaturellm.llm_interface.init_chat_model")
+
+    y = pd.Series([0.1, 0.9], name="target")
+    engineer = LLMFeatureEngineer(problem_type="regression", model_name="gpt-4o")
+    engineer.fit(sample_data_frame, y=y)
+
+    call_kwargs = mock_generate.call_args.kwargs
+    assert "dataset_statistics" in call_kwargs
+    assert "Target statistics:" in call_kwargs["dataset_statistics"]
+    assert "Feature statistics (numeric columns):" in call_kwargs["dataset_statistics"]
+
+
+def test_fit_without_y_dataset_statistics_not_provided(
+    mocker, sample_data_frame
+):  # pylint: disable=redefined-outer-name
+    """fit() without y still passes dataset_statistics containing 'Not provided.'."""
+    mock_ideas = Mock()
+    mock_ideas.ideas = []
+    mock_generate = mocker.patch(
+        "skfeaturellm.llm_interface.LLMInterface.generate_engineered_features",
+        return_value=mock_ideas,
+    )
+    mocker.patch("skfeaturellm.llm_interface.init_chat_model")
+
+    engineer = LLMFeatureEngineer(problem_type="regression", model_name="gpt-4o")
+    engineer.fit(sample_data_frame)
+
+    call_kwargs = mock_generate.call_args.kwargs
+    assert "dataset_statistics" in call_kwargs
+    assert "Not provided." in call_kwargs["dataset_statistics"]

--- a/tests/test_llm_interface.py
+++ b/tests/test_llm_interface.py
@@ -2,10 +2,12 @@
 
 from unittest.mock import Mock
 
+import pandas as pd
 import pytest
 
 from skfeaturellm.llm_interface import LLMInterface
 from skfeaturellm.schemas import FeatureEngineeringIdea
+from skfeaturellm.types import ProblemType
 
 
 @pytest.fixture
@@ -101,3 +103,119 @@ def test_generate_features(
     assert isinstance(result, list)
     assert len(result) == 1
     assert result[0].feature_name == "age_squared"
+
+
+# --- _format_dataset_statistics ---
+
+
+@pytest.fixture
+def regression_xy():
+    """Small regression dataset with one non-numeric column."""
+    X = pd.DataFrame(
+        {
+            "age": [25.0, 30.0, 35.0, 40.0, 45.0],
+            "income": [50_000.0, 60_000.0, 70_000.0, 80_000.0, 90_000.0],
+            "city": ["Paris", "Lyon", "Marseille", "Paris", "Lyon"],
+        }
+    )
+    y = pd.Series([1.5, 2.5, 3.5, 4.5, 5.5], name="target")
+    return X, y
+
+
+@pytest.fixture
+def classification_xy():
+    """Small binary classification dataset."""
+    X = pd.DataFrame(
+        {
+            "age": [25.0, 30.0, 35.0, 40.0, 45.0, 50.0],
+            "income": [50_000.0, 60_000.0, 70_000.0, 80_000.0, 90_000.0, 100_000.0],
+        }
+    )
+    y = pd.Series(["cat", "dog", "cat", "dog", "cat", "dog"], name="label")
+    return X, y
+
+
+def test_format_dataset_statistics_regression(
+    regression_xy,
+):  # pylint: disable=redefined-outer-name
+    """Target stats are min/max/mean/std; feature table and pearson_corr section present."""
+    X, y = regression_xy
+    result = LLMInterface._format_dataset_statistics(X, y, ProblemType.REGRESSION)
+
+    assert "Target statistics:" in result
+    assert (
+        "min=" in result and "max=" in result and "mean=" in result and "std=" in result
+    )
+    assert "Feature statistics (numeric columns):" in result
+    assert "age" in result
+    assert "skewness" in result
+    assert "Feature statistics vs target:" in result
+    assert "pearson_corr" in result
+
+
+def test_format_dataset_statistics_classification(
+    classification_xy,
+):  # pylint: disable=redefined-outer-name
+    """Target stats show class counts; vs-target shows class-mean columns, not pearson_corr."""
+    X, y = classification_xy
+    result = LLMInterface._format_dataset_statistics(X, y, ProblemType.CLASSIFICATION)
+
+    assert "Target statistics:" in result
+    assert "class 'cat'" in result
+    assert "class 'dog'" in result
+    assert "%" in result
+    assert "Feature statistics (numeric columns):" in result
+    assert "Feature statistics vs target:" in result
+    assert "pearson_corr" not in result
+    assert "cat" in result and "dog" in result
+
+
+def test_format_dataset_statistics_no_target(
+    regression_xy,
+):  # pylint: disable=redefined-outer-name
+    """When y is None, target block says 'Not provided.' and vs-target section is absent."""
+    X, _ = regression_xy
+    result = LLMInterface._format_dataset_statistics(X, None, ProblemType.REGRESSION)
+
+    assert "Not provided." in result
+    assert "Feature statistics (numeric columns):" in result
+    assert "Feature statistics vs target:" not in result
+
+
+def test_format_dataset_statistics_no_numeric_cols():
+    """When X has no numeric columns, feature block says 'No numeric features.'."""
+    X = pd.DataFrame({"city": ["Paris", "Lyon", "Marseille"]})
+    y = pd.Series([1.0, 2.0, 3.0], name="target")
+    result = LLMInterface._format_dataset_statistics(X, y, ProblemType.REGRESSION)
+
+    assert "No numeric features." in result
+    assert "Feature statistics vs target:" not in result
+
+
+# --- generate_prompt_context: dataset_statistics key ---
+
+
+def test_generate_prompt_context_includes_dataset_statistics(
+    mocker, sample_features
+):  # pylint: disable=redefined-outer-name
+    """dataset_statistics value is passed through to the prompt context dict."""
+    mocker.patch("skfeaturellm.llm_interface.init_chat_model")
+    llm = LLMInterface(model_name="gpt-4o", model_provider="openai")
+    stats = "Target statistics:\n  min=1, max=10"
+    ctx = llm.generate_prompt_context(
+        feature_descriptions=sample_features, dataset_statistics=stats
+    )
+
+    assert "dataset_statistics" in ctx
+    assert ctx["dataset_statistics"] == stats
+
+
+def test_generate_prompt_context_default_dataset_statistics(
+    mocker, sample_features
+):  # pylint: disable=redefined-outer-name
+    """When dataset_statistics is omitted, the key defaults to 'Not provided.'."""
+    mocker.patch("skfeaturellm.llm_interface.init_chat_model")
+    llm = LLMInterface(model_name="gpt-4o", model_provider="openai")
+    ctx = llm.generate_prompt_context(feature_descriptions=sample_features)
+
+    assert ctx["dataset_statistics"] == "Not provided."


### PR DESCRIPTION
## Summary

Auto-compute dataset statistics in `fit()` and inject them into the LLM prompt as a `{dataset_statistics}` block, giving the model real signal about the data before it suggests transformations — with zero extra effort from the user.

---

## What's in the stats block

### Target statistics

- **Regression**: min, max, mean, std  
- **Classification**: class counts + balance %

### Feature statistics  
*(numeric columns, features as rows — fixed 9 columns regardless of dataset size)*

- Full `describe()` output + skewness per feature  

### Feature statistics vs target  
*(only when `y` is provided to `fit()`)*

- **Regression**: Pearson correlation per feature  
- **Classification**: class-wise mean per feature (`groupby(y).mean().T`)

---

## Changes

- **`llm_interface.py`**  
  - Added `_format_dataset_statistics(X, y, problem_type)` static method  
  - Threaded `dataset_statistics` param through:
    - `generate_prompt_context()`  
    - `generate_engineered_features()`

- **`prompts.py`**  
  - Injected `{dataset_statistics}` placeholder between target description and additional context  

- **`feature_engineer.py`**  
  - `fit()` now accepts `y: Optional[pd.Series]`  
  - Stats computed and passed through the call chain  
  - Falls back to `"Not provided."` when `y` is absent  

- **`pyproject.toml`**  
  - Added `tabulate` (required by `to_markdown()`)  
  - Added `langchain-anthropic`  

---

## Tests

- 8 new tests covering:
  - All branches of the stats formatter  
  - Updated `generate_prompt_context`  
  - `fit()` with and without `y`  

**Total tests:** 121  
**Status:** ✅ All green  