### PR TITLE
Fix sklearn clone compatibility for LLMFeatureEngineer

### DIFF
--- a/skfeaturellm/feature_engineer.py
+++ b/skfeaturellm/feature_engineer.py
@@ -51,6 +51,10 @@ class LLMFeatureEngineer(
         max_features: Optional[int] = None,
         feature_prefix: str = "llm_feat_",
         verbose: int = 0,
+        model_provider: Optional[str] = None,
+        llm_kwargs: Optional[Dict[str, Any]] = None,
+        llm_interface: Optional[LLMInterface] = None,
+        feature_evaluator: Optional[FeatureEvaluator] = None,
         **kwargs,
     ):
         self.problem_type = ProblemType(problem_type)
@@ -59,7 +63,32 @@ class LLMFeatureEngineer(
         self.max_features = max_features
         self.feature_prefix = feature_prefix
         self.verbose = verbose
-        self.llm_interface = LLMInterface(model_name=model_name, **kwargs)
+        if llm_kwargs is not None and kwargs:
+            raise ValueError(
+                "Pass extra LLM options via llm_kwargs or keyword args, not both."
+            )
+
+        self.model_provider = model_provider
+        self.llm_kwargs = kwargs if llm_kwargs is None else llm_kwargs
+        self.llm_interface = llm_interface
+        self.feature_evaluator = feature_evaluator
+
+    @property
+    def _llm_interface(self) -> LLMInterface:
+        """Lazily create the LLM interface so clone()/get_params() stay sklearn-safe."""
+        if self.llm_interface is None:
+            llm_kwargs = dict(self.llm_kwargs)
+            if self.model_provider is not None:
+                llm_kwargs.setdefault("model_provider", self.model_provider)
+            self.llm_interface = LLMInterface(model_name=self.model_name, **llm_kwargs)
+        return self.llm_interface
+
+    @property
+    def _feature_evaluator(self) -> FeatureEvaluator:
+        """Lazily create the feature evaluator to avoid hidden constructor side effects."""
+        if self.feature_evaluator is None:
+            self.feature_evaluator = FeatureEvaluator(self.problem_type)
+        return self.feature_evaluator
 
     def fit(
         self,
@@ -100,7 +129,7 @@ class LLMFeatureEngineer(
 
         # Generate feature engineering ideas
         self.generated_features_ideas_ = (
-            self.llm_interface.generate_engineered_features(
+            self._llm_interface.generate_engineered_features(
                 feature_descriptions=feature_descriptions,
                 problem_type=self.problem_type.value,
                 target_description=target_description,
@@ -238,7 +267,7 @@ class LLMFeatureEngineer(
         dataset_statistics = prompt_utils.format_dataset_statistics(
             X, y, self.problem_type
         )
-        prompt_context = self.llm_interface.generate_prompt_context(
+        prompt_context = self._llm_interface.generate_prompt_context(
             feature_descriptions=feature_descriptions,
             target_description=target_description,
             problem_type=self.problem_type.value,
@@ -263,7 +292,7 @@ class LLMFeatureEngineer(
                 print("  Querying LLM...", flush=True)
 
             ideas_result, conversation_history = (
-                self.llm_interface.generate_engineered_features_iterative(
+                self._llm_interface.generate_engineered_features_iterative(
                     prompt_context=prompt_context,
                     conversation_history=conversation_history,
                     feedback_context=feedback_context,
@@ -479,7 +508,7 @@ class LLMFeatureEngineer(
         """
         check_is_fitted(self)
 
-        feature_evaluator = FeatureEvaluator(self.problem_type)
+        feature_evaluator = self._feature_evaluator
 
         X_transformed = self.transform(X) if not is_transformed else X
 

--- a/tests/test_feature_engineer.py
+++ b/tests/test_feature_engineer.py
@@ -1,10 +1,11 @@
 """Tests for the LLMFeatureEngineer class."""
 
-from unittest.mock import Mock
+from unittest.mock import Mock, patch
 
 import numpy as np
 import pandas as pd
 import pytest
+from sklearn.base import clone
 
 from skfeaturellm.exceptions import NotFittedError
 from skfeaturellm.feature_engineer import LLMFeatureEngineer
@@ -45,6 +46,26 @@ def test_initialization(mocker):
     assert engineer.target_col == "default"
     assert engineer.max_features == 3
     assert engineer.feature_prefix == "test_"
+
+
+def test_clone_produces_valid_unfitted_estimator():
+    """Clone should succeed and return an unfitted sklearn-compatible estimator."""
+    with patch("skfeaturellm.llm_interface.init_chat_model"):
+        engineer = LLMFeatureEngineer(
+            problem_type="classification",
+            model_name="gpt-4o",
+            target_col="target",
+            max_features=3,
+            feature_prefix="test_",
+            model_provider="openai",
+        )
+
+    cloned = clone(engineer)
+
+    assert isinstance(cloned, LLMFeatureEngineer)
+    assert cloned is not engineer
+    assert cloned.get_params() == engineer.get_params()
+    assert not hasattr(cloned, "generated_features_ideas_")
 
 
 def test_fit_no_features(


### PR DESCRIPTION
## Summary\n- make  sklearn-clone friendly by removing constructor side effects\n- lazily initialize  and \n- preserve LLM config through explicit estimator parameters\n- add a regression test covering  on an unfitted estimator\n\n## Why\nIssue #33 notes that  /  are instantiated in , which breaks core sklearn contracts around , , and pipeline serialization.\n\nIn practice,  could rebuild the estimator without the original LLM kwargs, causing unintended LLM initialization during cloning. This change keeps the estimator constructor side-effect free and verifies the expected unfitted clone behavior with a test.\n\n## Validation\n- \n